### PR TITLE
Moar code

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,6 +3,7 @@ source=mesher
 omit =
     mesher/__main__.py
     mesher/consts.py
+    mesher/exodusII.py
 
 [report]
 exclude_lines =

--- a/mesher/MainWindow.py
+++ b/mesher/MainWindow.py
@@ -149,6 +149,9 @@ class MainWindow(QtWidgets.QMainWindow):
         self.mesh_shortcut = QShortcut(QKeySequence("Ctrl+Return"), self)
         self.mesh_shortcut.activated.connect(self.onMeshClicked)
 
+        self.esc_shortcut = QShortcut(QKeySequence("Escape"), self)
+        self.esc_shortcut.activated.connect(self.onHideMeshingOptions)
+
     def setupVtk(self):
         self.vtk_render_window = self.vtk_widget.GetRenderWindow()
         self.vtk_interactor = self.vtk_render_window.GetInteractor()
@@ -645,3 +648,7 @@ class MainWindow(QtWidgets.QMainWindow):
         left = (width - dlg.width()) - margin
         top = margin
         dlg.setGeometry(left, top, dlg.width(), height)
+
+    def onHideMeshingOptions(self):
+        dlg = self.opts_tri_dlg
+        dlg.hide()

--- a/mesher/MainWindow.py
+++ b/mesher/MainWindow.py
@@ -3,8 +3,9 @@ import vtk
 import meshio
 from PyQt5 import QtWidgets, QtCore
 from PyQt5.QtWidgets import QMenuBar, QActionGroup, QApplication, \
-    QFileDialog
+    QFileDialog, QShortcut
 from PyQt5.QtCore import QEvent, QSettings, Qt
+from PyQt5.QtGui import QKeySequence
 from vtk.qt.QVTKRenderWindowInteractor import QVTKRenderWindowInteractor
 from mesher.AboutDialog import AboutDialog
 from mesher.MesherInteractorStyle2D import MesherInteractorStyle2D
@@ -145,7 +146,8 @@ class MainWindow(QtWidgets.QMainWindow):
         self.export_to_exodusii_action.setEnabled(self.mesh is not None)
 
     def connectSignals(self):
-        pass
+        self.mesh_shortcut = QShortcut(QKeySequence("Ctrl+Return"), self)
+        self.mesh_shortcut.activated.connect(self.onMeshClicked)
 
     def setupVtk(self):
         self.vtk_render_window = self.vtk_widget.GetRenderWindow()
@@ -633,7 +635,6 @@ class MainWindow(QtWidgets.QMainWindow):
     def showMeshingOptions(self):
         dlg = self.opts_tri_dlg
         self.updateMeshingOptionsGeometry(dlg)
-        # dlg.setGraphicsEffect(None)
         dlg.show()
 
     def updateMeshingOptionsGeometry(self, dlg):

--- a/mesher/MainWindow.py
+++ b/mesher/MainWindow.py
@@ -533,8 +533,8 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def onMeshClicked(self):
         if isinstance(self.info, meshpy.triangle.MeshInfo):
-            # TODO: pull opts from self.opts_tri_dlg
-            self.mesh = meshpy.triangle.build(self.info)
+            params = self.opts_tri_dlg.getParams()
+            self.mesh = meshpy.triangle.build(self.info, **params)
             grid = self.triangles2DToUnstructuredGrid(self.mesh)
         elif isinstance(self.info, meshpy.tet.MeshInfo):
             self.mesh = meshpy.tet.build(self.info)

--- a/mesher/MainWindow.py
+++ b/mesher/MainWindow.py
@@ -269,6 +269,9 @@ class MainWindow(QtWidgets.QMainWindow):
     def resizeEvent(self, event):
         super().resizeEvent(event)
         self.updateWidgets()
+        dlg = self.getMeshingOptionsDialog()
+        if dlg is not None:
+            self.updateMeshingOptionsGeometry(dlg)
 
     def writeSettings(self):
         self.settings.setValue("window/geometry", self.saveGeometry())
@@ -611,12 +614,6 @@ class MainWindow(QtWidgets.QMainWindow):
                 self.openFile(file_names[0])
         else:
             event.ignore()
-
-    def resizeEvent(self, event):
-        super().resizeEvent(event)
-        dlg = self.getMeshingOptionsDialog()
-        if dlg is not None:
-            self.updateMeshingOptionsGeometry(dlg)
 
     def showNotification(self, text, ms=2000):
         """

--- a/mesher/MainWindow.py
+++ b/mesher/MainWindow.py
@@ -38,10 +38,6 @@ class MainWindow(QtWidgets.QMainWindow):
         super().__init__()
         self.settings = QSettings("Mesher")
         self.about_dlg = None
-        self.opts_tri_dlg = OptionsTriangleWidget(self.settings, self)
-        self.opts_tri_dlg.mesh_button.clicked.connect(self.onMeshClicked)
-        self.opts_tet_dlg = OptionsTetGenWidget(self.settings, self)
-        self.opts_tet_dlg.mesh_button.clicked.connect(self.onMeshClicked)
 
         self.recent_files = []
         self.clear_recent_file = None
@@ -85,6 +81,13 @@ class MainWindow(QtWidgets.QMainWindow):
         self.setCentralWidget(self.vtk_widget)
 
         self.setupNotificationWidget()
+
+        self.opts_tri_dlg = OptionsTriangleWidget(self.settings, self)
+        self.opts_tri_dlg.mesh_button.clicked.connect(self.onMeshClicked)
+        self.opts_tri_dlg.setVisible(False)
+        self.opts_tet_dlg = OptionsTetGenWidget(self.settings, self)
+        self.opts_tet_dlg.mesh_button.clicked.connect(self.onMeshClicked)
+        self.opts_tet_dlg.setVisible(False)
 
     def setupNotificationWidget(self):
         self.notification = NotificationWidget(self)
@@ -529,7 +532,7 @@ class MainWindow(QtWidgets.QMainWindow):
         prop.SetPointSize(0)
 
     def onMesh(self):
-        self.opts_tri_dlg.show()
+        self.showMeshingOptions()
 
     def onMeshClicked(self):
         if isinstance(self.info, meshpy.triangle.MeshInfo):
@@ -604,6 +607,11 @@ class MainWindow(QtWidgets.QMainWindow):
         else:
             event.ignore()
 
+    def resizeEvent(self, event):
+        super().resizeEvent(event)
+        dlg = self.opts_tri_dlg
+        self.updateMeshingOptionsGeometry(dlg)
+
     def showNotification(self, text, ms=2000):
         """
         @param text Notification text
@@ -621,3 +629,18 @@ class MainWindow(QtWidgets.QMainWindow):
             self.notification.height())
         self.notification.setGraphicsEffect(None)
         self.notification.show(ms)
+
+    def showMeshingOptions(self):
+        dlg = self.opts_tri_dlg
+        self.updateMeshingOptionsGeometry(dlg)
+        # dlg.setGraphicsEffect(None)
+        dlg.show()
+
+    def updateMeshingOptionsGeometry(self, dlg):
+        dlg.adjustSize()
+        margin = 10
+        width = self.geometry().width()
+        height = self.geometry().height() - (2 * margin)
+        left = (width - dlg.width()) - margin
+        top = margin
+        dlg.setGeometry(left, top, dlg.width(), height)

--- a/mesher/MainWindow.py
+++ b/mesher/MainWindow.py
@@ -614,8 +614,9 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def resizeEvent(self, event):
         super().resizeEvent(event)
-        dlg = self.opts_tri_dlg
-        self.updateMeshingOptionsGeometry(dlg)
+        dlg = self.getMeshingOptionsDialog()
+        if dlg is not None:
+            self.updateMeshingOptionsGeometry(dlg)
 
     def showNotification(self, text, ms=2000):
         """
@@ -635,10 +636,19 @@ class MainWindow(QtWidgets.QMainWindow):
         self.notification.setGraphicsEffect(None)
         self.notification.show(ms)
 
+    def getMeshingOptionsDialog(self):
+        if self.dim == 2:
+            return self.opts_tri_dlg
+        elif self.dim == 3:
+            return self.opts_tet_dlg
+        else:
+            return None
+
     def showMeshingOptions(self):
-        dlg = self.opts_tri_dlg
-        self.updateMeshingOptionsGeometry(dlg)
-        dlg.show()
+        dlg = self.getMeshingOptionsDialog()
+        if dlg is not None:
+            self.updateMeshingOptionsGeometry(dlg)
+            dlg.show()
 
     def updateMeshingOptionsGeometry(self, dlg):
         dlg.adjustSize()
@@ -650,5 +660,6 @@ class MainWindow(QtWidgets.QMainWindow):
         dlg.setGeometry(left, top, dlg.width(), height)
 
     def onHideMeshingOptions(self):
-        dlg = self.opts_tri_dlg
-        dlg.hide()
+        dlg = self.getMeshingOptionsDialog()
+        if dlg is not None:
+            dlg.hide()

--- a/mesher/MeshingOptionsBaseWidget.py
+++ b/mesher/MeshingOptionsBaseWidget.py
@@ -1,0 +1,145 @@
+from PyQt5 import QtWidgets
+from PyQt5.QtWidgets import QCheckBox, QLabel, QLineEdit, QVBoxLayout, \
+    QHBoxLayout, QPushButton, QWidget, QSizePolicy
+from PyQt5.QtCore import Qt
+from PyQt5.QtGui import QDoubleValidator
+
+
+class MeshingOptionsBaseWidget(QWidget):
+
+    def __init__(self, settings, parent):
+        """
+        Inits MeshingOptionsBaseWidget
+
+        Args:
+            settings: Application QSettings objects to store the options into
+            parent: Parent widget
+        """
+        super().__init__(parent)
+
+        self.settings = settings
+
+        self.setAttribute(Qt.WA_StyledBackground, True)
+        self.setObjectName("options")
+        self.setStyleSheet("""
+            #options, #closeButton {
+                border-radius: 6px;
+                background-color: rgb(0, 0, 0);
+                color: #fff;
+            }
+            QLabel, QCheckBox {
+                background-color: rgb(0, 0, 0);
+                color: #fff;
+            }
+            """)
+
+        self.setupWidgets()
+
+        effect = QtWidgets.QGraphicsOpacityEffect()
+        effect.setOpacity(0.66)
+        self.setGraphicsEffect(effect)
+
+        self.setFixedWidth(300)
+        self.updateWidgets()
+        self.connectSignals()
+
+    def setupWidgets(self):
+        self.layout = QVBoxLayout()
+        self.layout.addSpacing(8)
+        self.layout.setContentsMargins(15, 4, 15, 17)
+
+        title_layout = QHBoxLayout()
+        self.title = QLabel()
+        self.title.setStyleSheet("""
+            font-weight: bold;
+            qproperty-alignment: AlignCenter;
+            """)
+        self.title.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+        title_layout.addWidget(self.title)
+
+        self.close_button = QPushButton("\u2716")
+        self.close_button.setObjectName("closeButton")
+        self.close_button.setStyleSheet("""
+            font-size: 20px;
+            """)
+        title_layout.addWidget(self.close_button)
+
+        self.layout.addLayout(title_layout)
+
+        for d in self.data:
+            if d['type'] == 'bool':
+                self.addCheckbox(d)
+            elif d['type'] == 'float':
+                self.addEditFloat(d)
+
+            self.layout.addSpacing(12)
+        self.layout.addStretch()
+
+        self.mesh_button = QPushButton("Mesh")
+        self.mesh_button.setStyleSheet("""
+            background-color: #eee;
+            """)
+        self.layout.addWidget(self.mesh_button)
+        self.setLayout(self.layout)
+
+    def updateWidgets(self):
+        pass
+
+    def connectSignals(self):
+        self.close_button.clicked.connect(self.hide)
+
+    def addCheckbox(self, item):
+        checkbox = QCheckBox(item['label'], self)
+        if item['value']:
+            checkbox.setCheckState(Qt.Checked)
+        else:
+            checkbox.setCheckState(Qt.Unchecked)
+        self.layout.addWidget(checkbox)
+        setattr(self, item['name'], checkbox)
+
+        if len(item['help']) > 0:
+            self.addHelpWidget(item, 18)
+
+        return checkbox
+
+    def addEditFloat(self, item):
+        layout = QHBoxLayout()
+        label = QLabel(item['label'])
+        layout.addWidget(label)
+        setattr(self, item['name'] + "_label", label)
+        lineedit = QLineEdit()
+        lineedit.setValidator(QDoubleValidator())
+        layout.addWidget(lineedit)
+        setattr(self, item['name'], lineedit)
+        self.layout.addLayout(layout)
+
+        if len(item['help']) > 0:
+            self.addHelpWidget(item, 0)
+
+        return lineedit
+
+    def addHelpWidget(self, item, indent):
+        help_label = QLabel(item['help'])
+        font = help_label.font()
+        font.setPointSizeF(font.pointSizeF() * 0.9)
+        help_label.setFont(font)
+        help_label.setWordWrap(True)
+        layout = QHBoxLayout()
+        layout.addWidget(help_label)
+        layout.setContentsMargins(indent, 0, 0, 0)
+        self.layout.addLayout(layout)
+
+    def getParams(self):
+        params = {}
+        for d in self.data:
+            widget = getattr(self, d['name'])
+            param_name = d['param']
+            if isinstance(widget, QtWidgets.QCheckBox):
+                params[param_name] = widget.checkState() == Qt.Checked
+            elif isinstance(widget, QtWidgets.QLineEdit):
+                text = widget.text()
+                if len(text) == 0:
+                    params[param_name] = None
+                else:
+                    params[param_name] = float(text)
+        return params

--- a/mesher/OptionsTetGenWidget.py
+++ b/mesher/OptionsTetGenWidget.py
@@ -1,8 +1,7 @@
-from PyQt5 import QtWidgets, QtCore
-from PyQt5.QtWidgets import QScrollArea, QVBoxLayout, QPushButton
+from mesher.MeshingOptionsBaseWidget import MeshingOptionsBaseWidget
 
 
-class OptionsTetGenWidget(QScrollArea):
+class OptionsTetGenWidget(MeshingOptionsBaseWidget):
 
     data = []
 
@@ -13,37 +12,11 @@ class OptionsTetGenWidget(QScrollArea):
             settings: Application QSettings objects to store the options into
             parent: Parent widget
         """
-        super().__init__(parent)
+        super().__init__(settings, parent)
+        self.title.setText("TetGen Options")
 
-        self.settings = settings
+    def updateWidgets(self):
+        pass
 
-        self.layout = QVBoxLayout()
-        self.layout.addSpacing(8)
-
-        self.setupWidgets()
-
-        w = QtWidgets.QWidget()
-        w.setLayout(self.layout)
-        self.setWidget(w)
-        self.setWindowTitle("TetGen Options")
-        self.setFixedWidth(300)
-        self.setWidgetResizable(True)
-        self.setWindowFlag(QtCore.Qt.Tool)
-
-        geom = self.settings.value("tet_opts/geometry")
-        default_size = QtCore.QSize(300, 700)
-        if geom is None:
-            self.resize(default_size)
-        else:
-            if not self.restoreGeometry(geom):
-                self.resize(default_size)
-
-    def setupWidgets(self):
-        self.layout.addStretch()
-
-        self.mesh_button = QPushButton("Mesh")
-        self.layout.addWidget(self.mesh_button)
-
-    def closeEvent(self, event):
-        self.settings.setValue("tet_opts/geometry", self.saveGeometry())
-        event.accept()
+    def connectSignals(self):
+        super().connectSignals()

--- a/mesher/OptionsTriangleWidget.py
+++ b/mesher/OptionsTriangleWidget.py
@@ -1,12 +1,8 @@
-from PyQt5 import QtWidgets, QtCore
-from PyQt5.QtWidgets import QScrollArea, QCheckBox, QLabel, QLineEdit, \
-    QVBoxLayout, QHBoxLayout, QPushButton, QWidget, QSizePolicy
 from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QDoubleValidator
-from mesher.ClickableLabel import ClickableLabel
+from mesher.MeshingOptionsBaseWidget import MeshingOptionsBaseWidget
 
 
-class OptionsTriangleWidget(QWidget):
+class OptionsTriangleWidget(MeshingOptionsBaseWidget):
 
     data = [
         {
@@ -70,73 +66,8 @@ class OptionsTriangleWidget(QWidget):
             settings: Application QSettings objects to store the options into
             parent: Parent widget
         """
-        super().__init__(parent)
-
-        self.settings = settings
-
-        self.setAttribute(Qt.WA_StyledBackground, True)
-        self.setObjectName("triangleOptions")
-        self.setStyleSheet("""
-            #triangleOptions, #closeButton {
-                border-radius: 6px;
-                background-color: rgb(0, 0, 0);
-                color: #fff;
-            }
-            QLabel, QCheckBox {
-                background-color: rgb(0, 0, 0);
-                color: #fff;
-            }
-            """)
-
-        self.setupWidgets()
-
-        effect = QtWidgets.QGraphicsOpacityEffect()
-        effect.setOpacity(0.66)
-        self.setGraphicsEffect(effect)
-
-        self.setFixedWidth(300)
-        self.updateWidgets()
-        self.connectSignals()
-
-    def setupWidgets(self):
-        self.layout = QVBoxLayout()
-        self.layout.addSpacing(8)
-        self.layout.setContentsMargins(15, 4, 15, 17)
-
-        title_layout = QHBoxLayout()
-        self.title = QLabel("Triangle Options")
-        self.title.setStyleSheet("""
-            font-weight: bold;
-            qproperty-alignment: AlignCenter;
-            """)
-        self.title.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
-        title_layout.addWidget(self.title)
-
-        self.close_button = QPushButton("\u2716")
-        self.close_button.setObjectName("closeButton")
-        self.close_button.setStyleSheet("""
-            font-size: 20px;
-            """)
-        title_layout.addWidget(self.close_button)
-
-        self.layout.addLayout(title_layout)
-
-        for d in self.data:
-            if d['type'] == 'bool':
-                self.addCheckbox(d)
-            elif d['type'] == 'float':
-                self.addEditFloat(d)
-
-            self.layout.addSpacing(12)
-        self.layout.addStretch()
-
-        self.mesh_button = QPushButton("Mesh")
-        self.mesh_button.setStyleSheet("""
-            background-color: #eee;
-            """)
-        # self.mesh_button.setAttribute(Qt.WA_StyledBackground, False)
-        self.layout.addWidget(self.mesh_button)
-        self.setLayout(self.layout)
+        super().__init__(settings, parent)
+        self.title.setText("Triangle Options")
 
     def updateWidgets(self):
         quality_meshing = self.quality_meshing.checkState() == Qt.Checked
@@ -144,61 +75,5 @@ class OptionsTriangleWidget(QWidget):
         self.minimal_angle_label.setEnabled(quality_meshing)
 
     def connectSignals(self):
+        super().connectSignals()
         self.quality_meshing.stateChanged.connect(self.updateWidgets)
-        self.close_button.clicked.connect(self.hide)
-
-    def addCheckbox(self, item):
-        checkbox = QCheckBox(item['label'], self)
-        if item['value']:
-            checkbox.setCheckState(Qt.Checked)
-        else:
-            checkbox.setCheckState(Qt.Unchecked)
-        self.layout.addWidget(checkbox)
-        setattr(self, item['name'], checkbox)
-
-        if len(item['help']) > 0:
-            self.addHelpWidget(item, 18)
-
-        return checkbox
-
-    def addEditFloat(self, item):
-        layout = QHBoxLayout()
-        label = QLabel(item['label'])
-        layout.addWidget(label)
-        setattr(self, item['name'] + "_label", label)
-        lineedit = QLineEdit()
-        lineedit.setValidator(QDoubleValidator())
-        layout.addWidget(lineedit)
-        setattr(self, item['name'], lineedit)
-        self.layout.addLayout(layout)
-
-        if len(item['help']) > 0:
-            self.addHelpWidget(item, 0)
-
-        return lineedit
-
-    def addHelpWidget(self, item, indent):
-        help_label = QLabel(item['help'])
-        font = help_label.font()
-        font.setPointSizeF(font.pointSizeF() * 0.9)
-        help_label.setFont(font)
-        help_label.setWordWrap(True)
-        layout = QHBoxLayout()
-        layout.addWidget(help_label)
-        layout.setContentsMargins(indent, 0, 0, 0)
-        self.layout.addLayout(layout)
-
-    def getParams(self):
-        params = {}
-        for d in self.data:
-            widget = getattr(self, d['name'])
-            param_name = d['param']
-            if isinstance(widget, QtWidgets.QCheckBox):
-                params[param_name] = widget.checkState() == Qt.Checked
-            elif isinstance(widget, QtWidgets.QLineEdit):
-                text = widget.text()
-                if len(text) == 0:
-                    params[param_name] = None
-                else:
-                    params[param_name] = float(text)
-        return params

--- a/tests/test_vtk_helpres.py
+++ b/tests/test_vtk_helpres.py
@@ -1,0 +1,77 @@
+from mesher import vtk_helpers
+import vtk
+from unittest.mock import MagicMock
+
+
+def test_build_point_array_2d():
+    points = [
+        [0, 0],
+        [1, 0],
+        [1, 1]
+    ]
+    pt_arr = vtk_helpers.buildPointArray2D(points)
+    assert isinstance(pt_arr, vtk.vtkPoints)
+    assert pt_arr.GetNumberOfPoints() == 3
+    # TODO: check coordinates
+
+
+def test_build_point_array_3d():
+    points = [
+        [0, 0, 0],
+        [1, 0, 0],
+        [1, 1, 0.5]
+    ]
+    pt_arr = vtk_helpers.buildPointArray3D(points)
+    assert isinstance(pt_arr, vtk.vtkPoints)
+    assert pt_arr.GetNumberOfPoints() == 3
+    # TODO: check coordinates
+
+
+def test_build_cell_array_vertex():
+    points = [
+        [0, 0, 0],
+        [1, 0, 0],
+        [1, 1, 0.5]
+    ]
+    cell_arr = vtk_helpers.buildCellArrayVertex(points)
+    assert isinstance(cell_arr, vtk.vtkCellArray)
+    assert cell_arr.GetNumberOfCells() == 3
+
+
+def test_build_cell_array_line():
+    points = [
+        [0, 1],
+        [1, 2]
+    ]
+    cell_arr = vtk_helpers.buildCellArrayLine(points)
+    assert isinstance(cell_arr, vtk.vtkCellArray)
+    assert cell_arr.GetNumberOfCells() == 2
+
+
+def test_build_cell_array_triangle():
+    points = [
+        [0, 1, 2],
+        [1, 2, 3]
+    ]
+    cell_arr = vtk_helpers.buildCellArrayTriangle(points)
+    assert isinstance(cell_arr, vtk.vtkCellArray)
+    assert cell_arr.GetNumberOfCells() == 2
+
+
+def test_build_cell_array_tetra():
+    points = [
+        [0, 1, 2, 3],
+        [1, 2, 3, 4]
+    ]
+    cell_arr = vtk_helpers.buildCellArrayTetra(points)
+    assert isinstance(cell_arr, vtk.vtkCellArray)
+    assert cell_arr.GetNumberOfCells() == 2
+
+
+def test_build_cell_array_polygon():
+    facets = [MagicMock()]
+    facets[0].polygons = [MagicMock()]
+    facets[0].polygons[0].vertices = [1, 2, 3]
+    cell_arr = vtk_helpers.buildCellArrayPolygon(facets)
+    assert isinstance(cell_arr, vtk.vtkCellArray)
+    assert cell_arr.GetNumberOfCells() == 1


### PR DESCRIPTION
- Pass parameters from GUI to triangle
- Meshing options now show up on a transparent widget on the right side
- Ctrl+Enter runs the meshing
- Adding keyboard shortcut for hiding meshing options
- Refactoring meshing options widgets
- Update codecoverage config
- Adding tests for vtk_helpers
